### PR TITLE
Replace \x08 with \b

### DIFF
--- a/lab-spinner/spinner_await.py
+++ b/lab-spinner/spinner_await.py
@@ -8,21 +8,17 @@
 
 import asyncio
 import itertools
-import sys
 
 
 async def spin(msg):  # <1>
-    write, flush = sys.stdout.write, sys.stdout.flush
     for char in itertools.cycle('|/—\\'):
         status = char + ' ' + msg
-        write(status)
-        flush()
-        write('\b' * len(status))
+        print('\r' + status, end='', flush=True)
         try:
             await asyncio.sleep(.1)  # <2>
         except asyncio.CancelledError:  # <3>
             break
-    write(' ' * len(status) + '\b' * len(status))
+    print('\r', end='', flush=True)
 
 
 async def slow_function():  # <4>

--- a/lab-spinner/spinner_await.py
+++ b/lab-spinner/spinner_await.py
@@ -17,12 +17,12 @@ async def spin(msg):  # <1>
         status = char + ' ' + msg
         write(status)
         flush()
-        write('\x08' * len(status))
+        write('\b' * len(status))
         try:
             await asyncio.sleep(.1)  # <2>
         except asyncio.CancelledError:  # <3>
             break
-    write(' ' * len(status) + '\x08' * len(status))
+    write(' ' * len(status) + '\b' * len(status))
 
 
 async def slow_function():  # <4>

--- a/lab-spinner/spinner_curio.py
+++ b/lab-spinner/spinner_curio.py
@@ -11,21 +11,17 @@
 
 import curio
 import itertools
-import sys
 
 
 async def spin(msg):  # <1>
-    write, flush = sys.stdout.write, sys.stdout.flush
     for char in itertools.cycle('|/-\\'):
         status = char + ' ' + msg
-        write(status)
-        flush()
-        write('\b' * len(status))
+        print('\r' + status, end='', flush=True)
         try:
             await curio.sleep(.1)  # <2>
         except curio.CancelledError:  # <3>
             break
-    write(' ' * len(status) + '\b' * len(status))
+    print('\r', end='')
 
 
 async def slow_function():  # <4>

--- a/lab-spinner/spinner_curio.py
+++ b/lab-spinner/spinner_curio.py
@@ -20,12 +20,12 @@ async def spin(msg):  # <1>
         status = char + ' ' + msg
         write(status)
         flush()
-        write('\x08' * len(status))
+        write('\b' * len(status))
         try:
             await curio.sleep(.1)  # <2>
         except curio.CancelledError:  # <3>
             break
-    write(' ' * len(status) + '\x08' * len(status))
+    write(' ' * len(status) + '\b' * len(status))
 
 
 async def slow_function():  # <4>

--- a/lab-spinner/spinner_thread.py
+++ b/lab-spinner/spinner_thread.py
@@ -9,19 +9,15 @@
 import threading
 import itertools
 import time
-import sys
 
 
 def spin(msg, done):  # <1>
-    write, flush = sys.stdout.write, sys.stdout.flush
     for char in itertools.cycle('|/-\\'):
         status = char + ' ' + msg
-        write(status)
-        flush()
-        write('\b' * len(status))
+        print('\r' + status, end='', flush=True)
         if done.wait(.1):  # <2>
             break  # <3>
-    write(' ' * len(status) + '\b' * len(status))
+    print('\r', end='')
 
 
 def slow_function():  # <4>

--- a/lab-spinner/spinner_thread.py
+++ b/lab-spinner/spinner_thread.py
@@ -18,10 +18,10 @@ def spin(msg, done):  # <1>
         status = char + ' ' + msg
         write(status)
         flush()
-        write('\x08' * len(status))
+        write('\b' * len(status))
         if done.wait(.1):  # <2>
             break  # <3>
-    write(' ' * len(status) + '\x08' * len(status))
+    write(' ' * len(status) + '\b' * len(status))
 
 
 def slow_function():  # <4>

--- a/lab-spinner/spinner_yield.py
+++ b/lab-spinner/spinner_yield.py
@@ -8,22 +8,18 @@
 
 import asyncio
 import itertools
-import sys
 
 
 @asyncio.coroutine  # <1>
 def spin(msg):
-    write, flush = sys.stdout.write, sys.stdout.flush
     for char in itertools.cycle('|/-\\'):
         status = char + ' ' + msg
-        write(status)
-        flush()
-        write('\b' * len(status))
+        print('\r' + status, end='', flush=True)
         try:
             yield from asyncio.sleep(.1)  # <2>
         except asyncio.CancelledError:  # <3>
             break
-    write(' ' * len(status) + '\b' * len(status))
+    print('\r', end='')
 
 
 @asyncio.coroutine  # <4>

--- a/lab-spinner/spinner_yield.py
+++ b/lab-spinner/spinner_yield.py
@@ -18,12 +18,12 @@ def spin(msg):
         status = char + ' ' + msg
         write(status)
         flush()
-        write('\x08' * len(status))
+        write('\b' * len(status))
         try:
             yield from asyncio.sleep(.1)  # <2>
         except asyncio.CancelledError:  # <3>
             break
-    write(' ' * len(status) + '\x08' * len(status))
+    write(' ' * len(status) + '\b' * len(status))
 
 
 @asyncio.coroutine  # <4>


### PR DESCRIPTION
I think `\b` (for **b**ackspace) is more legible than `\x08` -- this is what the first commit does.
But we don't actually need `sys.stdout` object since the `print` function can receive `flush` and `end` and we can use carriage return (`\r`) to remove the entire line (the `' ' * len(status) + '\b' * len(status)` "magic" is not needed), then the verbosity of `sys.stdout.write/flush` are not needed.